### PR TITLE
fix(kafka-rules): generate per-policy documentation for all four rules

### DIFF
--- a/src/policy/kafka-rules/README_alter_topic.tmpl
+++ b/src/policy/kafka-rules/README_alter_topic.tmpl
@@ -1,15 +1,7 @@
 # Kafka Alter Topic Rules Policy
 
-[![Gravitee.io](https://img.shields.io/static/v1?label=Available%20at&message=Gravitee.io&color=1EC9D2)](https://download.gravitee.io/#graviteeio-apim/plugins/policies/gravitee-policy-{{ .Plugin.ID }}/)
-[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/gravitee-io/gravitee-policy-{{ .Plugin.ID }}/blob/master/LICENSE.txt)
-
 ## Overview
 {{ .AlterTopicOverview.Content }}
-{{ if .Usage.Exists }}
-
-## Usage
-{{ .Usage.Content }}
-{{ end }}
 {{ if .Errors.Exists }}
 
 ## Errors
@@ -24,7 +16,3 @@ The `{{ .Plugin.ID }}` policy can be applied to the following API types and flow
 ## Configuration options
 {{ .AlterTopicConfigurationOptions.Content}}
 {{ end }}
-
-## Examples
-{{ .GenExamples.Content }}
-{{ .RawExamples.Content }}

--- a/src/policy/kafka-rules/README_create_topic.tmpl
+++ b/src/policy/kafka-rules/README_create_topic.tmpl
@@ -1,15 +1,7 @@
 # Kafka Create Topic Rules Policy
 
-[![Gravitee.io](https://img.shields.io/static/v1?label=Available%20at&message=Gravitee.io&color=1EC9D2)](https://download.gravitee.io/#graviteeio-apim/plugins/policies/gravitee-policy-{{ .Plugin.ID }}/)
-[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/gravitee-io/gravitee-policy-{{ .Plugin.ID }}/blob/master/LICENSE.txt)
-
 ## Overview
 {{ .CreateTopicOverview.Content }}
-{{ if .Usage.Exists }}
-
-## Usage
-{{ .Usage.Content }}
-{{ end }}
 {{ if .Errors.Exists }}
 
 ## Errors
@@ -24,7 +16,3 @@ The `{{ .Plugin.ID }}` policy can be applied to the following API types and flow
 ## Configuration options
 {{ .CreateTopicConfigurationOptions.Content}}
 {{ end }}
-
-## Examples
-{{ .GenExamples.Content }}
-{{ .RawExamples.Content }}

--- a/src/policy/kafka-rules/README_fetch.tmpl
+++ b/src/policy/kafka-rules/README_fetch.tmpl
@@ -1,15 +1,7 @@
 # Kafka Fetch Rules Policy
 
-[![Gravitee.io](https://img.shields.io/static/v1?label=Available%20at&message=Gravitee.io&color=1EC9D2)](https://download.gravitee.io/#graviteeio-apim/plugins/policies/gravitee-policy-{{ .Plugin.ID }}/)
-[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/gravitee-io/gravitee-policy-{{ .Plugin.ID }}/blob/master/LICENSE.txt)
-
 ## Overview
 {{ .FetchOverview.Content }}
-{{ if .Usage.Exists }}
-
-## Usage
-{{ .Usage.Content }}
-{{ end }}
 {{ if .Errors.Exists }}
 
 ## Errors
@@ -24,7 +16,3 @@ The `{{ .Plugin.ID }}` policy can be applied to the following API types and flow
 ## Configuration options
 {{ .FetchConfigurationOptions.Content}}
 {{ end }}
-
-## Examples
-{{ .GenExamples.Content }}
-{{ .RawExamples.Content }}

--- a/src/policy/kafka-rules/README_produce.tmpl
+++ b/src/policy/kafka-rules/README_produce.tmpl
@@ -1,15 +1,7 @@
 # Kafka Produce Rules Policy
 
-[![Gravitee.io](https://img.shields.io/static/v1?label=Available%20at&message=Gravitee.io&color=1EC9D2)](https://download.gravitee.io/#graviteeio-apim/plugins/policies/gravitee-policy-{{ .Plugin.ID }}/)
-[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/gravitee-io/gravitee-policy-{{ .Plugin.ID }}/blob/master/LICENSE.txt)
-
 ## Overview
 {{ .ProduceOverview.Content }}
-{{ if .Usage.Exists }}
-
-## Usage
-{{ .Usage.Content }}
-{{ end }}
 {{ if .Errors.Exists }}
 
 ## Errors
@@ -24,7 +16,3 @@ The `{{ .Plugin.ID }}` policy can be applied to the following API types and flow
 ## Configuration options
 {{ .ProduceConfigurationOptions.Content}}
 {{ end }}
-
-## Examples
-{{ .GenExamples.Content }}
-{{ .RawExamples.Content }}

--- a/src/policy/kafka-rules/default.yaml
+++ b/src/policy/kafka-rules/default.yaml
@@ -16,16 +16,18 @@ outputs:
  - template : "{{ .RootDir }}/{{ .Plugin.Type }}/{{ .Plugin.ID }}/README.tmpl"
    target: README.md
    processExisting: true
- - template : "{{ .RootDir }}/{{ .Plugin.Type }}/POLICY_STUDIO_DOC.tmpl"
-   target: docs/POLICY_STUDIO_DOC.md
  - template : "{{ .RootDir }}/{{ .Plugin.Type }}/{{ .Plugin.ID }}/README_produce.tmpl"
-   target: gravitee-policy-kafka-produce-rules/README.md
+   target: gravitee-policy-kafka-produce-rules/docs/POLICY_STUDIO_DOC.md
+   processExisting: true
  - template : "{{ .RootDir }}/{{ .Plugin.Type }}/{{ .Plugin.ID }}/README_fetch.tmpl"
-   target: gravitee-policy-kafka-fetch-rules/README.md
+   target: gravitee-policy-kafka-fetch-rules/docs/POLICY_STUDIO_DOC.md
+   processExisting: true
  - template : "{{ .RootDir }}/{{ .Plugin.Type }}/{{ .Plugin.ID }}/README_create_topic.tmpl"
-   target: gravitee-policy-kafka-create-topic-rules/README.md
+   target: gravitee-policy-kafka-create-topic-rules/docs/POLICY_STUDIO_DOC.md
+   processExisting: true
  - template : "{{ .RootDir }}/{{ .Plugin.Type }}/{{ .Plugin.ID }}/README_alter_topic.tmpl"
-   target: gravitee-policy-kafka-alter-topic-rules/README.md
+   target: gravitee-policy-kafka-alter-topic-rules/docs/POLICY_STUDIO_DOC.md
+   processExisting: true
 chunks:
   - template: .docgen/overview.md
     required: true


### PR DESCRIPTION
https://gravitee.atlassian.net/browse/APIM-13058

- Generate per-policy `POLICY_STUDIO_DOC.md` (in `docs/`) for each of the four
  kafka-rules sub-modules (produce, fetch, create-topic, alter-topic)
- Remove shared `docs/POLICY_STUDIO_DOC.md` output — not useful for multi-module repos
- Simplify sub-module templates to overview + phases + configuration options (no examples;
  examples remain in the root README only)