### PR TITLE
fix(gamma-module): render README the way prettier formats markdown

### DIFF
--- a/src/gamma-module/README.tmpl
+++ b/src/gamma-module/README.tmpl
@@ -4,7 +4,8 @@
 [![CircleCI](https://circleci.com/gh/gravitee-io/gravitee-{{ .Plugin.Type }}-{{ .Plugin.ID }}.svg?style=svg)](https://circleci.com/gh/gravitee-io/gravitee-{{ .Plugin.Type }}-{{ .Plugin.ID }})
 
 ## Overview
-{{ .Overview.Content }}
 
+{{ .Overview.Content }}
 ## Compatibility matrix
-{{ .Matrix.Content }}
+
+{{ .Matrix.Content -}}

--- a/src/gamma-module/default.yaml
+++ b/src/gamma-module/default.yaml
@@ -18,7 +18,7 @@ outputs:
 chunks:
   - template: .docgen/overview.md
     required: true
-  - template: "{{ .RootDir }}/matrix.tmpl"
+  - template: "{{ .RootDir }}/{{ .Plugin.Type }}/matrix.tmpl"
     type: table
     required: true
     data:

--- a/src/gamma-module/matrix.tmpl
+++ b/src/gamma-module/matrix.tmpl
@@ -1,0 +1,41 @@
+{{- /*
+  Same table as the shared matrix.tmpl, but padded the way Prettier formats
+  markdown tables: every column is as wide as its widest cell (minimum 3),
+  header and delimiter row included. Gamma module repositories run
+  `prettier --check .` over their README, so an unpadded table would make the
+  lint job and the doc-gen "no diff" job contradict each other.
+*/ -}}
+{{- $dashes := "----------------------------------------------------------------------------------------------------" -}}
+{{- $head := "" -}}
+{{- $delimiter := "" -}}
+{{- range $col := .Columns -}}
+  {{- $width := len $col.Label -}}
+  {{- range $row := $.Rows -}}
+    {{- $cell := printf "%v" (default (index $row.Data $col.ID) "-") -}}
+    {{- if $row.Deprecated }}{{ $cell = printf "~~%s~~" $cell }}{{ end -}}
+    {{- if lt $width (len $cell) }}{{ $width = len $cell }}{{ end -}}
+  {{- end -}}
+  {{- if lt $width 3 }}{{ $width = 3 }}{{ end -}}
+  {{- $head = printf "%s| %-*s " $head $width $col.Label -}}
+  {{- $delimiter = printf "%s| %s " $delimiter (slice $dashes 0 $width) -}}
+{{- end -}}
+Strikethrough text indicates that a version is deprecated.
+
+{{ $head }}|
+{{ $delimiter }}|
+{{ range $row := .Rows -}}
+  {{- $line := "" -}}
+  {{- range $col := $.Columns -}}
+    {{- $width := len $col.Label -}}
+    {{- range $other := $.Rows -}}
+      {{- $cell := printf "%v" (default (index $other.Data $col.ID) "-") -}}
+      {{- if $other.Deprecated }}{{ $cell = printf "~~%s~~" $cell }}{{ end -}}
+      {{- if lt $width (len $cell) }}{{ $width = len $cell }}{{ end -}}
+    {{- end -}}
+    {{- if lt $width 3 }}{{ $width = 3 }}{{ end -}}
+    {{- $cell := printf "%v" (default (index $row.Data $col.ID) "-") -}}
+    {{- if $row.Deprecated }}{{ $cell = printf "~~%s~~" $cell }}{{ end -}}
+    {{- $line = printf "%s| %-*s " $line $width $cell -}}
+  {{- end -}}
+  {{- printf "%s|\n" $line -}}
+{{- end -}}


### PR DESCRIPTION
Gamma module repositories run `prettier --check .` over the whole repo, README included, so a README generated with an unpadded table and loose blank lines made the lint job and the doc-gen "no diff" job contradict each other.

The gamma-module README template now emits exactly one blank line between blocks, and a dedicated matrix template pads every column to its widest cell, which is what prettier does. The shared matrix.tmpl is left untouched so policy repositories keep their current output.